### PR TITLE
Support v3 API for radarr/sonarr

### DIFF
--- a/SonarrAutoImport/SonarrImporter.cs
+++ b/SonarrAutoImport/SonarrImporter.cs
@@ -333,7 +333,7 @@ namespace SonarrAuto
 
                 var request = new RestRequest(Method.POST);
 
-                request.Resource = isLidarr ? "api/v1/command" : "api/command";
+                request.Resource = isLidarr ? "api/v1/command" : "api/v3/command";
                 request.RequestFormat = DataFormat.Json;
                 request.AddJsonBody(payload);
                 request.AddHeader("User-Agent", "Sonarr Auto-Import");


### PR DESCRIPTION
Old api endpoint is now completely removed in both Radarr and Sonarr so need to target the /v3/ endpoint for requests.

Tested locally with Radarr 4.2.4.6605 and Sonarr 4.0.0.115